### PR TITLE
Secure data file resolution with pathlib

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
+from path_utils import get_validated_file_path
 from datetime import datetime
 import xml.etree.ElementTree as ET
 import csv
@@ -2229,17 +2230,19 @@ async def check_processing_status(preset_id: str):
 
 @app.get("/download/data_files/{filename}")
 def download_csv(filename: str):
-    file_path = os.path.join("data_files", filename)
-    if os.path.isfile(file_path):
-        # Security check - ensure filename doesn't contain path traversal
-        if '..' in filename or '/' in filename or '\\' in filename:
-            raise HTTPException(status_code=400, detail="Invalid filename")
-        
-        return FileResponse(path=file_path,
-                            filename=filename,
-                            media_type='application/octet-stream',
-                            headers={"Access-Control-Allow-Origin": "*"})
-    raise HTTPException(status_code=404, detail="File not found")
+    try:
+        file_path = get_validated_file_path(filename)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid filename")
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="File not found")
+
+    return FileResponse(
+        path=file_path,
+        filename=file_path.name,
+        media_type="application/octet-stream",
+        headers={"Access-Control-Allow-Origin": "*"},
+    )
 
 
 if __name__ == "__main__":

--- a/path_utils.py
+++ b/path_utils.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+DATA_FILES_DIR = Path("data_files").resolve()
+
+
+def get_validated_file_path(filename: str) -> Path:
+    """Resolve and validate that filename is within DATA_FILES_DIR and is a file.
+
+    Raises:
+        ValueError: If the resolved path is outside DATA_FILES_DIR.
+        FileNotFoundError: If the resolved path is not an existing file.
+    """
+    file_path = (DATA_FILES_DIR / filename).resolve()
+    try:
+        file_path.relative_to(DATA_FILES_DIR)
+    except ValueError as exc:  # path traversal attempt
+        raise ValueError("Invalid filename") from exc
+
+    if not file_path.is_file():
+        raise FileNotFoundError("File not found")
+
+    return file_path

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -1,0 +1,25 @@
+import os
+from pathlib import Path
+import sys
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from path_utils import get_validated_file_path, DATA_FILES_DIR
+
+
+def test_get_validated_file_path_valid(tmp_path):
+    sample = DATA_FILES_DIR / "sample.txt"
+    sample.write_text("data")
+    result = get_validated_file_path("sample.txt")
+    assert result == sample
+
+
+def test_get_validated_file_path_malicious():
+    with pytest.raises(ValueError):
+        get_validated_file_path("../main.py")
+
+
+def test_get_validated_file_path_not_found():
+    with pytest.raises(FileNotFoundError):
+        get_validated_file_path("missing.txt")


### PR DESCRIPTION
## Summary
- Use `pathlib` to resolve and validate `data_files` paths
- Reject invalid paths or missing files and return 404/400 accordingly
- Add unit tests covering valid, malicious, and missing filenames

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68932686f3ec832680ee0c4f474c8655